### PR TITLE
chore(cicd): adding additional linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,143 @@
+linters:
+  enable:
+    - revive
+    - sloglint
+    - godox
+    - gosec
+    - musttag
+    - nilnil
+    - goconst
+    - gocritic
+    - gofmt
+    - iface
+    - thelper
+    - tparallel
+issues:
+  exclude-rules:
+    - path: (.+)_test.go
+      linters:
+        - revive
+      text: "^(enforce-slice-style|enforce-map-style)"
+linters-settings:
+  revive:
+    # Default: false
+    ignore-generated-header: true
+    # Default: 0.8
+    confidence: 0.1
+    rules:
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#context-as-argument
+      - name: context-as-argument
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#early-return
+      - name: early-return
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "preserveScope"
+          - "allowJump"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-map-style
+      - name: enforce-map-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-slice-style
+      - name: enforce-slice-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#filename-format
+      - name: filename-format
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "^[_a-z][_a-z0-9]*.go$"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#optimize-operands-order
+      - name: optimize-operands-order
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+  sloglint:
+    # Enforce using attributes only (overrides no-mixed-args, incompatible with kv-only).
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#attributes-only
+    # Default: false
+    attr-only: true
+    # Enforce using static values for log messages.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#static-messages
+    # Default: false
+    static-msg: true
+    # Enforce using constants instead of raw keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-raw-keys
+    # Default: false
+    no-raw-keys: true
+    # Enforce a single key naming convention.
+    # Values: snake, kebab, camel, pascal
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#key-naming-convention
+    # Default: ""
+    key-naming-case: snake
+    # Enforce not using specific keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#forbidden-keys
+    # Default: []
+    forbidden-keys:
+      - time
+      - level
+      - msg
+      - source
+      - foo
+    # Enforce putting arguments on separate lines.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#arguments-on-separate-lines
+    # Default: false
+    args-on-sep-lines: true
+  goconst:
+    # Ignore test files.
+    # Default: false
+    ignore-tests: true
+    # Ignore when constant is not used as function argument.
+    # Default: true
+    ignore-calls: true
+    # Exclude strings matching the given regular expression.
+    # Default: ""
+    ignore-strings: ''
+  nilnil:
+    # In addition, detect opposite situation (simultaneous return of non-nil error and valid value).
+    # Default: false
+    detect-opposite: true
+    # List of return types to check.
+    # Default: ["chan", "func", "iface", "map", "ptr", "uintptr", "unsafeptr"]
+    checked-types:
+      - chan
+      - func
+      - iface
+      - map
+      - ptr
+      - uintptr
+      - unsafeptr
+  gocritic:
+    enable-all: true
+  gofmt:
+    # Simplify code: gofmt with `-s` option.
+    # Default: true
+    simplify: false
+    # Apply the rewrite rules to the source before reformatting.
+    # https://pkg.go.dev/cmd/gofmt
+    # Default: []
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
+      - pattern: 'a[b:len(a)]'
+        replacement: 'a[b:]'
+  iface:
+    # List of analyzers.
+    # Default: ["identical"]
+    enable:
+      - identical # Identifies interfaces in the same package that have identical method sets.
+      - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.

--- a/filter.go
+++ b/filter.go
@@ -34,23 +34,24 @@ func (m *MultiFilter) Add(f any) {
 		m.joinArgs = append(m.joinArgs, joinArgs...)
 	}
 
-	if wt, okWt := f.(WhereTyper); okWt {
-		whereSQL, whereArgs := wt.Where()
+	switch f := f.(type) {
+	case WhereTyper:
+		whereSQL, whereArgs := f.Where()
 		if whereArgs == nil {
 			whereArgs = make([]any, 0)
 		}
 		wtStr := WhereTypeAnd
-		if wt.WhereType().IsValid() {
-			wtStr = wt.WhereType()
+		if f.WhereType().IsValid() {
+			wtStr = f.WhereType()
 		}
 		m.whereSQL.WriteString(string(wtStr) + " ")
 		m.whereSQL.WriteString(strings.TrimSpace(whereSQL))
 		m.whereSQL.WriteString("\n")
 		m.whereArgs = append(m.whereArgs, whereArgs...)
-	} else if w, ok := f.(Wherer); ok {
-		whereSQL, whereArgs := w.Where()
+	case Wherer:
+		whereSQL, whereArgs := f.Where()
 		if whereArgs == nil {
-			whereArgs = []any{}
+			whereArgs = make([]any, 0)
 		}
 		m.whereSQL.WriteString(string(WhereTypeAnd) + " ") // default to AND
 		m.whereSQL.WriteString(strings.TrimSpace(whereSQL))
@@ -63,11 +64,11 @@ func (m *MultiFilter) Add(f any) {
 	}
 }
 
-func (m *MultiFilter) Join() (string, []any) {
+func (m *MultiFilter) Join() (sqlStr string, args []any) {
 	return strings.TrimSpace(m.joinSQL.String()), m.joinArgs
 }
 
-func (m *MultiFilter) Where() (string, []any) {
+func (m *MultiFilter) Where() (sqlStr string, args []any) {
 	return strings.TrimSpace(m.whereSQL.String()), m.whereArgs
 }
 

--- a/query_builder.go
+++ b/query_builder.go
@@ -149,16 +149,17 @@ func (p *Paginator) First() (string, error) {
 	sqlBuilder.WriteString(" ASC \n")
 	sqlBuilder.WriteString("LIMIT 1")
 
-	args := append(jArgs, wArgs...)
+	sqlArgs := jArgs
+	sqlArgs = append(sqlArgs, wArgs...)
 	var err error
 	sql := sqlBuilder.String()
-	sql, args, err = sqlx.In(sql, args...)
+	sql, sqlArgs, err = sqlx.In(sql, sqlArgs...)
 	if err != nil {
 		return "", fmt.Errorf("first sql in: %w", err)
 	}
 
 	var pivot string
-	err = p.db.Get(&pivot, sql, args...)
+	err = p.db.Get(&pivot, sql, sqlArgs...)
 	if err != nil {
 		return "", fmt.Errorf("first select: %w", err)
 	}
@@ -213,7 +214,8 @@ func (p *Paginator) pivotFromValue() (string, error) {
 	sqlBuilder.WriteString(" ASC \n")
 	sqlBuilder.WriteString("LIMIT 1")
 
-	args := append(jArgs, p.details.LastVal)
+	args := jArgs
+	args = append(args, p.details.LastVal)
 	args = append(args, wArgs...)
 
 	sql := sqlBuilder.String()
@@ -279,18 +281,19 @@ func (p *Paginator) pivotFromID() (string, error) {
 	sqlBuilder.WriteString(" ASC \n")
 	sqlBuilder.WriteString("LIMIT 1")
 
-	args := append(jArgs, p.details.LastID)
-	args = append(args, wArgs...)
+	sqlArgs := jArgs
+	sqlArgs = append(sqlArgs, p.details.LastID)
+	sqlArgs = append(sqlArgs, wArgs...)
 
 	sql := sqlBuilder.String()
 	var err error
-	sql, args, err = sqlx.In(sql, args...)
+	sql, sqlArgs, err = sqlx.In(sql, sqlArgs...)
 	if err != nil {
 		return "", fmt.Errorf("pivot from id sql in: %w", err)
 	}
 
 	var pivot string
-	err = p.db.Get(&pivot, sql, args...)
+	err = p.db.Get(&pivot, sql, sqlArgs...)
 	if err != nil {
 		return "", fmt.Errorf("pivot from id select: %w", err)
 	}
@@ -301,11 +304,12 @@ func (p *Paginator) pivotFromID() (string, error) {
 // Pivot finds the pivot point in the data.
 func (p *Paginator) Pivot() (string, error) {
 	// We were given no information about where to pivot from, pivot from the first value
-	if p.details.LastID == "" && p.details.LastVal == "" {
+	switch {
+	case p.details.LastID == "" && p.details.LastVal == "":
 		return p.First()
-	} else if p.details.LastID == "" && p.details.LastVal != "" {
+	case p.details.LastID == "" && p.details.LastVal != "":
 		return p.pivotFromValue()
-	} else if p.details.LastID != "" && p.details.LastVal == "" {
+	case p.details.LastID != "" && p.details.LastVal == "":
 		return p.pivotFromID()
 	}
 
@@ -350,7 +354,8 @@ func (p *Paginator) Pivot() (string, error) {
 
 	sqlBuilder.WriteString("LIMIT 1")
 
-	args := append(jArgs, p.details.LastVal, p.details.LastID)
+	args := jArgs
+	args = append(args, p.details.LastVal, p.details.LastID)
 	args = append(args, wArgs...)
 
 	sql := sqlBuilder.String()
@@ -492,7 +497,8 @@ func (p *Paginator) Retrieve(pivot string, dest any) error {
 	sqlBuilder.WriteString(p.idKey)
 	sqlBuilder.WriteString(" ASC \n")
 
-	args := append(jArgs, pivot, pivot, p.details.LastID)
+	args := jArgs
+	args = append(args, pivot, pivot, p.details.LastID)
 	args = append(args, wArgs...)
 
 	if p.details.Limit > 0 {
@@ -553,7 +559,8 @@ func (p *Paginator) Counts(dest *int64) error {
 
 	sql := sqlBuilder.String()
 
-	args := append(jArgs, wArgs...)
+	args := jArgs
+	args = append(args, wArgs...)
 	var err error
 	sql, args, err = sqlx.In(sql, args...)
 	if err != nil {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes significant updates to the Go codebase, primarily focusing on enhancing the linter configurations and refactoring several functions for improved clarity and maintainability. The most important changes are detailed below:

### Linter Configuration Enhancements:
* Added multiple linters to the `.golangci.yaml` file, including `revive`, `sloglint`, `godox`, `gosec`, `musttag`, `nilnil`, `goconst`, `gocritic`, `gofmt`, `iface`, `thelper`, and `tparallel`. Configured specific rules and settings for each linter to enforce coding standards and improve code quality.

### Function Refactoring:
* Refactored the `Add` method in `filter.go` to use a type switch instead of type assertions, improving readability and maintainability.
* Updated the `Join` and `Where` methods in `filter.go` to use named return values for better clarity.

### SQL Argument Handling:
* Modified several methods in `query_builder.go` (`First`, `pivotFromValue`, `pivotFromID`, `Pivot`, `Retrieve`, and `Counts`) to change how SQL arguments are handled. These changes ensure that arguments are appended in a more consistent and readable manner. [[1]](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL152-R162) [[2]](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL216-R218) [[3]](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL282-R296) [[4]](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL304-R312) [[5]](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL353-R358) [[6]](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL495-R501) [[7]](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL556-R563)