### PR TITLE
chore(cicd): updating enabled linters to lint sprint formats

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,9 @@ linters:
     - iface
     - thelper
     - tparallel
+    - intrange
+    - testifylint
+    - perfsprint
 issues:
   exclude-rules:
     - path: (.+)_test.go
@@ -141,3 +144,5 @@ linters-settings:
     enable:
       - identical # Identifies interfaces in the same package that have identical method sets.
       - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.
+  testifylint:
+    enable-all: true

--- a/query_builder.go
+++ b/query_builder.go
@@ -92,7 +92,7 @@ func (p *Paginator) First() (string, error) {
 	wSQL, wArgs := p.filter.Where()
 	var gSQL string
 	if g, ok := p.filter.(Grouper); ok && len(g.Group()) > 0 {
-		gSQL = fmt.Sprintf("GROUP BY %s", strings.Join(g.Group(), ", "))
+		gSQL = "GROUP BY " + strings.Join(g.Group(), ", ")
 	}
 
 	// Be aware of SQL injection if modifying the below SQL. Any parameters in the sprintf
@@ -154,7 +154,7 @@ func (p *Paginator) pivotFromValue() (string, error) {
 	wSQL, wArgs := p.filter.Where()
 	var gSQL string
 	if g, ok := p.filter.(Grouper); ok && len(g.Group()) > 0 {
-		gSQL = fmt.Sprintf("GROUP BY %s", strings.Join(g.Group(), ", "))
+		gSQL = "GROUP BY " + strings.Join(g.Group(), ", ")
 	}
 
 	// Be aware of SQL injection if modifying the below SQL. Any parameters in the sprintf
@@ -221,7 +221,7 @@ func (p *Paginator) pivotFromID() (string, error) {
 	wSQL, wArgs := p.filter.Where()
 	var gSQL string
 	if g, ok := p.filter.(Grouper); ok && len(g.Group()) > 0 {
-		gSQL = fmt.Sprintf("GROUP BY %s", strings.Join(g.Group(), ", "))
+		gSQL = "GROUP BY " + strings.Join(g.Group(), ", ")
 	}
 
 	// Be aware of SQL injection if modifying the below SQL. Any parameters in the sprintf
@@ -299,7 +299,7 @@ func (p *Paginator) Pivot() (string, error) {
 	wSQL, wArgs := p.filter.Where()
 	var gSQL string
 	if g, ok := p.filter.(Grouper); ok && len(g.Group()) > 0 {
-		gSQL = fmt.Sprintf("GROUP BY %s", strings.Join(g.Group(), ", "))
+		gSQL = "GROUP BY " + strings.Join(g.Group(), ", ")
 	}
 
 	// Be aware of SQL injection if modifying the below SQL. Any parameters in the sprintf
@@ -380,7 +380,7 @@ func (p *Paginator) Retrieve(pivot string, dest any) error {
 	}
 
 	cols := new(strings.Builder)
-	for i := 0; i < elemType.NumField(); i++ {
+	for i := range elemType.NumField() {
 		field := elemType.Field(i)
 		dbTag := field.Tag.Get("db")
 		switch dbTag {
@@ -432,7 +432,7 @@ func (p *Paginator) Retrieve(pivot string, dest any) error {
 	wSQL, wArgs := p.filter.Where()
 	var gSQL string
 	if g, ok := p.filter.(Grouper); ok && len(g.Group()) > 0 {
-		gSQL = fmt.Sprintf("GROUP BY %s", strings.Join(g.Group(), ", "))
+		gSQL = "GROUP BY " + strings.Join(g.Group(), ", ")
 	}
 
 	// Be aware of SQL injection if modifying the below SQL. Any parameters in the sprintf
@@ -515,7 +515,7 @@ func (p *Paginator) Counts(dest *int64) error {
 	wSQL, wArgs := p.filter.Where()
 	var gSQL string
 	if g, ok := p.filter.(Grouper); ok && len(g.Group()) > 0 {
-		gSQL = fmt.Sprintf("GROUP BY %s", strings.Join(g.Group(), ", "))
+		gSQL = "GROUP BY " + strings.Join(g.Group(), ", ")
 	}
 
 	// Be aware of SQL injection if modifying the below SQL. Any parameters in the sprintf


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes updates to the `.golangci.yaml` configuration and several refactoring changes in the `query_builder.go` file to improve code quality and readability.

### Configuration updates:

* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R15-R17): Added new linters `intrange`, `testifylint`, and `perfsprint` to the `linters` section. Enabled all rules for `testifylint` in the `linters-settings` section. [[1]](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R15-R17) [[2]](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R147-R148)

### Code refactoring:

* [`query_builder.go`](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL95-R95): Replaced `fmt.Sprintf` with string concatenation for the `GROUP BY` SQL clause in multiple methods to simplify the code. [[1]](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL95-R95) [[2]](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL157-R157) [[3]](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL224-R224) [[4]](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL302-R302) [[5]](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL435-R435) [[6]](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL518-R518)
* [`query_builder.go`](diffhunk://#diff-f743979b44c7e6587ffa5c3d58479c9cd189e2053d54dcc8858a0a839f7a5c7bL383-R383): Changed the loop variable in the `Retrieve` method to use `range` for better readability.