### PR TITLE
chore(docs): improving docs on query params

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,6 @@ linters:
     - tparallel
   settings:
     goconst:
-      ignore-strings: ""
       ignore-calls: true
     gocritic:
       enable-all: true

--- a/common/common.yaml
+++ b/common/common.yaml
@@ -4,10 +4,11 @@ components:
     limit_param:
       name: limit
       in: query
-      description: Report type
+      description: Pagination details, maximum number of records to return.
       schema:
         type: integer
-        example: 10
+        example: 100
+        default: 100
     last_value:
       name: last_val
       in: query

--- a/paginator_details.go
+++ b/paginator_details.go
@@ -66,12 +66,14 @@ func getLimit(q url.Values) (limit int, err error) {
 	return limit, nil
 }
 
-func getOffset(q url.Values) (offset int, err error) {
-	offset = -1
-	if offsetStr := q.Get(QueryOffset); offsetStr != "" {
-		if offset, err = strconv.Atoi(offsetStr); err != nil {
-			return -1, fmt.Errorf("invalid offset: %w", err)
-		}
+func getOffset(q url.Values) (int, error) {
+	offsetStr := q.Get(QueryOffset)
+	if offsetStr == "" {
+		return 0, nil
+	}
+	offset, err := strconv.Atoi(offsetStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid offset: %w", err)
 	}
 	return offset, nil
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes updates to improve pagination functionality and enhance the clarity of the API documentation. The most important changes include refining the `limit_param` description and default value in the API schema, and simplifying the `getOffset` function for better readability and default handling.

### API Documentation Updates:
* [`common/common.yaml`](diffhunk://#diff-3f815ffe7258f764700e107c86fa82f749fa9b7e22db708e5d89a1788ec92708L7-R11): Updated the `limit_param` description to clarify its purpose as "Pagination details, maximum number of records to return." Changed the example value to `100` and added a default value of `100` for consistency.

### Code Simplification:
* [`paginator_details.go`](diffhunk://#diff-3b358ae364dd6de27e6fe5aa6894167673e35c97338ebc77a53ea61c9dedb63aL69-R76): Refactored the `getOffset` function to simplify its logic. Removed unnecessary initialization of `offset` and ensured a default return value of `0` when the `QueryOffset` parameter is not provided.